### PR TITLE
Add SimulatorException to Simulator.step

### DIFF
--- a/src/edu/asu/plp/tool/backend/isa/Simulator.java
+++ b/src/edu/asu/plp/tool/backend/isa/Simulator.java
@@ -6,7 +6,7 @@ public interface Simulator
 {
 	boolean isRunning();
 	
-	void run();
+	void run() throws SimulatorException;
 	
 	boolean step() throws SimulatorException;
 	

--- a/src/edu/asu/plp/tool/backend/isa/Simulator.java
+++ b/src/edu/asu/plp/tool/backend/isa/Simulator.java
@@ -1,12 +1,14 @@
 package edu.asu.plp.tool.backend.isa;
 
+import edu.asu.plp.tool.backend.isa.exceptions.SimulatorException;
+
 public interface Simulator
 {
 	boolean isRunning();
 	
 	void run();
 	
-	boolean step();
+	boolean step() throws SimulatorException;
 	
 	void reset();
 	

--- a/src/edu/asu/plp/tool/backend/plpisa/sim/PLPSimulator.java
+++ b/src/edu/asu/plp/tool/backend/plpisa/sim/PLPSimulator.java
@@ -8,6 +8,7 @@ import com.google.common.eventbus.EventBus;
 
 import edu.asu.plp.tool.backend.isa.ASMImage;
 import edu.asu.plp.tool.backend.isa.Simulator;
+import edu.asu.plp.tool.backend.isa.exceptions.SimulatorException;
 import edu.asu.plp.tool.backend.plpisa.InstructionExtractor;
 import edu.asu.plp.tool.backend.plpisa.PLPASMImage;
 import edu.asu.plp.tool.backend.plpisa.sim.stages.ExecuteStage;
@@ -142,7 +143,7 @@ public class PLPSimulator implements Simulator
 	}
 	
 	@Override
-	public boolean step()
+	public boolean step() throws SimulatorException
 	{
 		statusManager.advanceFlags();
 		instructionsIssued++;

--- a/src/edu/asu/plp/tool/backend/tools/SimulatorConsole.java
+++ b/src/edu/asu/plp/tool/backend/tools/SimulatorConsole.java
@@ -8,6 +8,7 @@ import edu.asu.plp.tool.backend.isa.ASMImage;
 import edu.asu.plp.tool.backend.isa.Assembler;
 import edu.asu.plp.tool.backend.isa.Simulator;
 import edu.asu.plp.tool.backend.isa.exceptions.AssemblerException;
+import edu.asu.plp.tool.backend.isa.exceptions.SimulatorException;
 import edu.asu.plp.tool.backend.plpisa.assembler.PLPAssembler;
 import edu.asu.plp.tool.backend.plpisa.sim.PLPSimulator;
 import edu.asu.plp.tool.backend.util.FileUtil;
@@ -49,7 +50,12 @@ public class SimulatorConsole
 			System.exit(-1);
 		}
 		
-		simulator.step();
+		try {
+			simulator.step();
+		} catch (SimulatorException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
 		
 		long endTime = System.nanoTime();
 		

--- a/src/edu/asu/plp/tool/prototype/Main.java
+++ b/src/edu/asu/plp/tool/prototype/Main.java
@@ -1577,7 +1577,12 @@ public class Main extends Application implements Controller
 			simRunThread = new Thread(new Runnable(){
 				public void run()
 				{
-					activeSimulator.run();
+					try {
+						activeSimulator.run();
+					} catch (SimulatorException e) {
+						// TODO Auto-generated catch block
+						e.printStackTrace();
+					}
 				}
 			});
 			simRunThread.start();

--- a/src/edu/asu/plp/tool/prototype/Main.java
+++ b/src/edu/asu/plp/tool/prototype/Main.java
@@ -81,6 +81,7 @@ import edu.asu.plp.tool.backend.isa.ASMInstruction;
 import edu.asu.plp.tool.backend.isa.Assembler;
 import edu.asu.plp.tool.backend.isa.Simulator;
 import edu.asu.plp.tool.backend.isa.exceptions.AssemblerException;
+import edu.asu.plp.tool.backend.isa.exceptions.SimulatorException;
 import edu.asu.plp.tool.backend.plpisa.sim.PLPMemoryModule;
 import edu.asu.plp.tool.backend.plpisa.sim.PLPRegFile;
 import edu.asu.plp.tool.core.ISAModule;
@@ -1527,7 +1528,14 @@ public class Main extends Application implements Controller
 	@Override
 	public void stepSimulation()
 	{
-		performIfActive(activeSimulator::step);
+		performIfActive(() -> {
+			try {
+				activeSimulator.step();
+			} catch (SimulatorException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+		});
 	}
 	
 	private void performIfActive(Subroutine subroutine)


### PR DESCRIPTION
This allows us to capture Simulator based Exceptions(like Overflow) and
print them to PLPTool's console from Main.